### PR TITLE
avoid joining table name prematurely while handling `UPDATE` command

### DIFF
--- a/src/apiproto/api_grpc.rs
+++ b/src/apiproto/api_grpc.rs
@@ -4,6 +4,7 @@
 // https://github.com/Manishearth/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
+
 #![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
@@ -15,48 +16,25 @@
 #![allow(unused_imports)]
 #![allow(unused_results)]
 
-const METHOD_INSPEKTOR_AUTH: ::grpcio::Method<super::api::AuthRequest, super::api::AuthResponse> =
-    ::grpcio::Method {
-        ty: ::grpcio::MethodType::Unary,
-        name: "/api.Inspektor/Auth",
-        req_mar: ::grpcio::Marshaller {
-            ser: ::grpcio::pb_ser,
-            de: ::grpcio::pb_de,
-        },
-        resp_mar: ::grpcio::Marshaller {
-            ser: ::grpcio::pb_ser,
-            de: ::grpcio::pb_de,
-        },
-    };
+const METHOD_INSPEKTOR_AUTH: ::grpcio::Method<super::api::AuthRequest, super::api::AuthResponse> = ::grpcio::Method {
+    ty: ::grpcio::MethodType::Unary,
+    name: "/api.Inspektor/Auth",
+    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+};
 
-const METHOD_INSPEKTOR_POLICY: ::grpcio::Method<super::api::Empty, super::api::InspektorPolicy> =
-    ::grpcio::Method {
-        ty: ::grpcio::MethodType::ServerStreaming,
-        name: "/api.Inspektor/Policy",
-        req_mar: ::grpcio::Marshaller {
-            ser: ::grpcio::pb_ser,
-            de: ::grpcio::pb_de,
-        },
-        resp_mar: ::grpcio::Marshaller {
-            ser: ::grpcio::pb_ser,
-            de: ::grpcio::pb_de,
-        },
-    };
+const METHOD_INSPEKTOR_POLICY: ::grpcio::Method<super::api::Empty, super::api::InspektorPolicy> = ::grpcio::Method {
+    ty: ::grpcio::MethodType::ServerStreaming,
+    name: "/api.Inspektor/Policy",
+    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+};
 
-const METHOD_INSPEKTOR_GET_DATA_SOURCE: ::grpcio::Method<
-    super::api::Empty,
-    super::api::DataSourceResponse,
-> = ::grpcio::Method {
+const METHOD_INSPEKTOR_GET_DATA_SOURCE: ::grpcio::Method<super::api::Empty, super::api::DataSourceResponse> = ::grpcio::Method {
     ty: ::grpcio::MethodType::Unary,
     name: "/api.Inspektor/GetDataSource",
-    req_mar: ::grpcio::Marshaller {
-        ser: ::grpcio::pb_ser,
-        de: ::grpcio::pb_de,
-    },
-    resp_mar: ::grpcio::Marshaller {
-        ser: ::grpcio::pb_ser,
-        de: ::grpcio::pb_de,
-    },
+    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
 };
 
 #[derive(Clone)]
@@ -71,111 +49,54 @@ impl InspektorClient {
         }
     }
 
-    pub fn auth_opt(
-        &self,
-        req: &super::api::AuthRequest,
-        opt: ::grpcio::CallOption,
-    ) -> ::grpcio::Result<super::api::AuthResponse> {
+    pub fn auth_opt(&self, req: &super::api::AuthRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<super::api::AuthResponse> {
         self.client.unary_call(&METHOD_INSPEKTOR_AUTH, req, opt)
     }
 
-    pub fn auth(
-        &self,
-        req: &super::api::AuthRequest,
-    ) -> ::grpcio::Result<super::api::AuthResponse> {
+    pub fn auth(&self, req: &super::api::AuthRequest) -> ::grpcio::Result<super::api::AuthResponse> {
         self.auth_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn auth_async_opt(
-        &self,
-        req: &super::api::AuthRequest,
-        opt: ::grpcio::CallOption,
-    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::AuthResponse>> {
-        self.client
-            .unary_call_async(&METHOD_INSPEKTOR_AUTH, req, opt)
+    pub fn auth_async_opt(&self, req: &super::api::AuthRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::AuthResponse>> {
+        self.client.unary_call_async(&METHOD_INSPEKTOR_AUTH, req, opt)
     }
 
-    pub fn auth_async(
-        &self,
-        req: &super::api::AuthRequest,
-    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::AuthResponse>> {
+    pub fn auth_async(&self, req: &super::api::AuthRequest) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::AuthResponse>> {
         self.auth_async_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn policy_opt(
-        &self,
-        req: &super::api::Empty,
-        opt: ::grpcio::CallOption,
-    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::api::InspektorPolicy>> {
-        self.client
-            .server_streaming(&METHOD_INSPEKTOR_POLICY, req, opt)
+    pub fn policy_opt(&self, req: &super::api::Empty, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::api::InspektorPolicy>> {
+        self.client.server_streaming(&METHOD_INSPEKTOR_POLICY, req, opt)
     }
 
-    pub fn policy(
-        &self,
-        req: &super::api::Empty,
-    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::api::InspektorPolicy>> {
+    pub fn policy(&self, req: &super::api::Empty) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::api::InspektorPolicy>> {
         self.policy_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn get_data_source_opt(
-        &self,
-        req: &super::api::Empty,
-        opt: ::grpcio::CallOption,
-    ) -> ::grpcio::Result<super::api::DataSourceResponse> {
-        self.client
-            .unary_call(&METHOD_INSPEKTOR_GET_DATA_SOURCE, req, opt)
+    pub fn get_data_source_opt(&self, req: &super::api::Empty, opt: ::grpcio::CallOption) -> ::grpcio::Result<super::api::DataSourceResponse> {
+        self.client.unary_call(&METHOD_INSPEKTOR_GET_DATA_SOURCE, req, opt)
     }
 
-    pub fn get_data_source(
-        &self,
-        req: &super::api::Empty,
-    ) -> ::grpcio::Result<super::api::DataSourceResponse> {
+    pub fn get_data_source(&self, req: &super::api::Empty) -> ::grpcio::Result<super::api::DataSourceResponse> {
         self.get_data_source_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn get_data_source_async_opt(
-        &self,
-        req: &super::api::Empty,
-        opt: ::grpcio::CallOption,
-    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::DataSourceResponse>> {
-        self.client
-            .unary_call_async(&METHOD_INSPEKTOR_GET_DATA_SOURCE, req, opt)
+    pub fn get_data_source_async_opt(&self, req: &super::api::Empty, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::DataSourceResponse>> {
+        self.client.unary_call_async(&METHOD_INSPEKTOR_GET_DATA_SOURCE, req, opt)
     }
 
-    pub fn get_data_source_async(
-        &self,
-        req: &super::api::Empty,
-    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::DataSourceResponse>> {
+    pub fn get_data_source_async(&self, req: &super::api::Empty) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::DataSourceResponse>> {
         self.get_data_source_async_opt(req, ::grpcio::CallOption::default())
     }
-    pub fn spawn<F>(&self, f: F)
-    where
-        F: ::futures::Future<Output = ()> + Send + 'static,
-    {
+    pub fn spawn<F>(&self, f: F) where F: ::futures::Future<Output = ()> + Send + 'static {
         self.client.spawn(f)
     }
 }
 
 pub trait Inspektor {
-    fn auth(
-        &mut self,
-        ctx: ::grpcio::RpcContext,
-        req: super::api::AuthRequest,
-        sink: ::grpcio::UnarySink<super::api::AuthResponse>,
-    );
-    fn policy(
-        &mut self,
-        ctx: ::grpcio::RpcContext,
-        req: super::api::Empty,
-        sink: ::grpcio::ServerStreamingSink<super::api::InspektorPolicy>,
-    );
-    fn get_data_source(
-        &mut self,
-        ctx: ::grpcio::RpcContext,
-        req: super::api::Empty,
-        sink: ::grpcio::UnarySink<super::api::DataSourceResponse>,
-    );
+    fn auth(&mut self, ctx: ::grpcio::RpcContext, req: super::api::AuthRequest, sink: ::grpcio::UnarySink<super::api::AuthResponse>);
+    fn policy(&mut self, ctx: ::grpcio::RpcContext, req: super::api::Empty, sink: ::grpcio::ServerStreamingSink<super::api::InspektorPolicy>);
+    fn get_data_source(&mut self, ctx: ::grpcio::RpcContext, req: super::api::Empty, sink: ::grpcio::UnarySink<super::api::DataSourceResponse>);
 }
 
 pub fn create_inspektor<S: Inspektor + Send + Clone + 'static>(s: S) -> ::grpcio::Service {
@@ -185,14 +106,12 @@ pub fn create_inspektor<S: Inspektor + Send + Clone + 'static>(s: S) -> ::grpcio
         instance.auth(ctx, req, resp)
     });
     let mut instance = s.clone();
-    builder = builder
-        .add_server_streaming_handler(&METHOD_INSPEKTOR_POLICY, move |ctx, req, resp| {
-            instance.policy(ctx, req, resp)
-        });
+    builder = builder.add_server_streaming_handler(&METHOD_INSPEKTOR_POLICY, move |ctx, req, resp| {
+        instance.policy(ctx, req, resp)
+    });
     let mut instance = s;
-    builder = builder
-        .add_unary_handler(&METHOD_INSPEKTOR_GET_DATA_SOURCE, move |ctx, req, resp| {
-            instance.get_data_source(ctx, req, resp)
-        });
+    builder = builder.add_unary_handler(&METHOD_INSPEKTOR_GET_DATA_SOURCE, move |ctx, req, resp| {
+        instance.get_data_source(ctx, req, resp)
+    });
     builder.build()
 }

--- a/src/sql/query_rewriter.rs
+++ b/src/sql/query_rewriter.rs
@@ -163,7 +163,7 @@ impl<T: RuleEngine + Clone> QueryRewriter<T> {
         // postgres update will have only one table so it's safe to
         // find the table and validate the whether it's allowed to update.
         let table_name = match &table.relation {
-            TableFactor::Table { name, .. } => join_indents(&name.0),
+            TableFactor::Table { name, .. } => name.0.clone(),
             _ => {
                 warn!(
                     "unexpected releationship for the update statement table {:?}",
@@ -180,7 +180,7 @@ impl<T: RuleEngine + Clone> QueryRewriter<T> {
             }
         }
         if !self.is_operation_allowed(
-            &ObjectName(vec![Ident::new(table_name)]),
+            &ObjectName(table_name),
             &columns,
             self.rule_engine.get_allowed_update_attributes(),
         ) {
@@ -1276,7 +1276,7 @@ mod tests {
             update_allowed: true,
             update_allowed_attributes: HashMap::from([(
                 String::from("public.kids"),
-                vec![String::from("phone")],
+                vec![String::from("mobile_number")],
             )]),
             ..Default::default()
         };
@@ -1285,8 +1285,8 @@ mod tests {
         assert_rewriter(
             &rewriter,
             state,
-            "UPDATE kids SET phone = 'Dramatic' WHERE phone = '9843421696';",
-            "UPDATE kids SET phone = 'Dramatic' WHERE phone = '9843421696'",
+            "UPDATE public.kids SET mobile_number = 'Dramatic' WHERE mobile_number = '9843421696';",
+            "UPDATE public.kids SET mobile_number = 'Dramatic' WHERE mobile_number = '9843421696'",
         );
     }
 


### PR DESCRIPTION
`is_operation_allowed` requires table name as `ident` vector. 
This PR, remove the prematurely table name concatenation and pass the ident vector directly to the `is_operation_allowed`

close #17 

Signed-off-by: poonai <rbalajis25@gmail.com>