### PR TITLE
Fix possible typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ role_permission := {
 "copy": {"allowed": false, "allowed_attributes": {}, "protected_attributes":{}},
  
 # support role can view every columns of the database except email column of customers table.
-"view": {"allowed": true, "protected_attributes": {"http://prod.public.customers.email"}}, }}],
+"view": {"allowed": true, "protected_attributes": {"prod.public.customers.email"}}, }}],
 }
 
 # retrive all the resources that can be accessible by the 


### PR DESCRIPTION
Hi, 

I just noticed an unexpected `http://`prefix in one of the examples, where it should refer to an database attribute. Could be that a local $EDITOR saw the string, decided it looked like domain and added the prefix?