### PR TITLE
add support for multiple statement query. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /controlplane/inspektor
 /controlplane/dashboard/node_modules
 /controlplane/policy_dir
+dataplane_config.yaml

--- a/controlplane/dashboard/src/store/store.js
+++ b/controlplane/dashboard/src/store/store.js
@@ -70,7 +70,7 @@ const store = createStore({
             // merge session and meta in same object.
             for (let i = 0; i < datasources.length; i++) {
                 for (let j = 0; j < sessions.length; j++) {
-                    if (sessions[j].objectID == datasources[i].id && sessions[j].meta.expiresAt == 0) {
+                    if (sessions[j].objectID == datasources[i].id && (sessions[j].meta.expiresAt == 0 || sessions[j].meta.expiresAt == undefined)) {
                         datasources[i].sessionMeta = sessions[j].meta
                     }
                 }
@@ -78,7 +78,7 @@ const store = createStore({
             commit("setDatasource", datasources)
             let tempSesions = await api.getTempCredentials()
             let tempDatasources = []
-            for (let k= 0; k< tempSesions.length; k++){
+            for (let k = 0; k < tempSesions.length; k++) {
                 let datasource = tempSesions[k].datasource;
                 datasource.sessionMeta = tempSesions[k]
                 tempDatasources.push(datasource)

--- a/src/apiproto/api_grpc.rs
+++ b/src/apiproto/api_grpc.rs
@@ -4,7 +4,6 @@
 // https://github.com/Manishearth/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
-
 #![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
@@ -16,25 +15,48 @@
 #![allow(unused_imports)]
 #![allow(unused_results)]
 
-const METHOD_INSPEKTOR_AUTH: ::grpcio::Method<super::api::AuthRequest, super::api::AuthResponse> = ::grpcio::Method {
-    ty: ::grpcio::MethodType::Unary,
-    name: "/api.Inspektor/Auth",
-    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
-    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
-};
+const METHOD_INSPEKTOR_AUTH: ::grpcio::Method<super::api::AuthRequest, super::api::AuthResponse> =
+    ::grpcio::Method {
+        ty: ::grpcio::MethodType::Unary,
+        name: "/api.Inspektor/Auth",
+        req_mar: ::grpcio::Marshaller {
+            ser: ::grpcio::pb_ser,
+            de: ::grpcio::pb_de,
+        },
+        resp_mar: ::grpcio::Marshaller {
+            ser: ::grpcio::pb_ser,
+            de: ::grpcio::pb_de,
+        },
+    };
 
-const METHOD_INSPEKTOR_POLICY: ::grpcio::Method<super::api::Empty, super::api::InspektorPolicy> = ::grpcio::Method {
-    ty: ::grpcio::MethodType::ServerStreaming,
-    name: "/api.Inspektor/Policy",
-    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
-    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
-};
+const METHOD_INSPEKTOR_POLICY: ::grpcio::Method<super::api::Empty, super::api::InspektorPolicy> =
+    ::grpcio::Method {
+        ty: ::grpcio::MethodType::ServerStreaming,
+        name: "/api.Inspektor/Policy",
+        req_mar: ::grpcio::Marshaller {
+            ser: ::grpcio::pb_ser,
+            de: ::grpcio::pb_de,
+        },
+        resp_mar: ::grpcio::Marshaller {
+            ser: ::grpcio::pb_ser,
+            de: ::grpcio::pb_de,
+        },
+    };
 
-const METHOD_INSPEKTOR_GET_DATA_SOURCE: ::grpcio::Method<super::api::Empty, super::api::DataSourceResponse> = ::grpcio::Method {
+const METHOD_INSPEKTOR_GET_DATA_SOURCE: ::grpcio::Method<
+    super::api::Empty,
+    super::api::DataSourceResponse,
+> = ::grpcio::Method {
     ty: ::grpcio::MethodType::Unary,
     name: "/api.Inspektor/GetDataSource",
-    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
-    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    req_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
+    resp_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
 };
 
 #[derive(Clone)]
@@ -49,54 +71,111 @@ impl InspektorClient {
         }
     }
 
-    pub fn auth_opt(&self, req: &super::api::AuthRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<super::api::AuthResponse> {
+    pub fn auth_opt(
+        &self,
+        req: &super::api::AuthRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<super::api::AuthResponse> {
         self.client.unary_call(&METHOD_INSPEKTOR_AUTH, req, opt)
     }
 
-    pub fn auth(&self, req: &super::api::AuthRequest) -> ::grpcio::Result<super::api::AuthResponse> {
+    pub fn auth(
+        &self,
+        req: &super::api::AuthRequest,
+    ) -> ::grpcio::Result<super::api::AuthResponse> {
         self.auth_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn auth_async_opt(&self, req: &super::api::AuthRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::AuthResponse>> {
-        self.client.unary_call_async(&METHOD_INSPEKTOR_AUTH, req, opt)
+    pub fn auth_async_opt(
+        &self,
+        req: &super::api::AuthRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::AuthResponse>> {
+        self.client
+            .unary_call_async(&METHOD_INSPEKTOR_AUTH, req, opt)
     }
 
-    pub fn auth_async(&self, req: &super::api::AuthRequest) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::AuthResponse>> {
+    pub fn auth_async(
+        &self,
+        req: &super::api::AuthRequest,
+    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::AuthResponse>> {
         self.auth_async_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn policy_opt(&self, req: &super::api::Empty, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::api::InspektorPolicy>> {
-        self.client.server_streaming(&METHOD_INSPEKTOR_POLICY, req, opt)
+    pub fn policy_opt(
+        &self,
+        req: &super::api::Empty,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::api::InspektorPolicy>> {
+        self.client
+            .server_streaming(&METHOD_INSPEKTOR_POLICY, req, opt)
     }
 
-    pub fn policy(&self, req: &super::api::Empty) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::api::InspektorPolicy>> {
+    pub fn policy(
+        &self,
+        req: &super::api::Empty,
+    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::api::InspektorPolicy>> {
         self.policy_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn get_data_source_opt(&self, req: &super::api::Empty, opt: ::grpcio::CallOption) -> ::grpcio::Result<super::api::DataSourceResponse> {
-        self.client.unary_call(&METHOD_INSPEKTOR_GET_DATA_SOURCE, req, opt)
+    pub fn get_data_source_opt(
+        &self,
+        req: &super::api::Empty,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<super::api::DataSourceResponse> {
+        self.client
+            .unary_call(&METHOD_INSPEKTOR_GET_DATA_SOURCE, req, opt)
     }
 
-    pub fn get_data_source(&self, req: &super::api::Empty) -> ::grpcio::Result<super::api::DataSourceResponse> {
+    pub fn get_data_source(
+        &self,
+        req: &super::api::Empty,
+    ) -> ::grpcio::Result<super::api::DataSourceResponse> {
         self.get_data_source_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn get_data_source_async_opt(&self, req: &super::api::Empty, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::DataSourceResponse>> {
-        self.client.unary_call_async(&METHOD_INSPEKTOR_GET_DATA_SOURCE, req, opt)
+    pub fn get_data_source_async_opt(
+        &self,
+        req: &super::api::Empty,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::DataSourceResponse>> {
+        self.client
+            .unary_call_async(&METHOD_INSPEKTOR_GET_DATA_SOURCE, req, opt)
     }
 
-    pub fn get_data_source_async(&self, req: &super::api::Empty) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::DataSourceResponse>> {
+    pub fn get_data_source_async(
+        &self,
+        req: &super::api::Empty,
+    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::api::DataSourceResponse>> {
         self.get_data_source_async_opt(req, ::grpcio::CallOption::default())
     }
-    pub fn spawn<F>(&self, f: F) where F: ::futures::Future<Output = ()> + Send + 'static {
+    pub fn spawn<F>(&self, f: F)
+    where
+        F: ::futures::Future<Output = ()> + Send + 'static,
+    {
         self.client.spawn(f)
     }
 }
 
 pub trait Inspektor {
-    fn auth(&mut self, ctx: ::grpcio::RpcContext, req: super::api::AuthRequest, sink: ::grpcio::UnarySink<super::api::AuthResponse>);
-    fn policy(&mut self, ctx: ::grpcio::RpcContext, req: super::api::Empty, sink: ::grpcio::ServerStreamingSink<super::api::InspektorPolicy>);
-    fn get_data_source(&mut self, ctx: ::grpcio::RpcContext, req: super::api::Empty, sink: ::grpcio::UnarySink<super::api::DataSourceResponse>);
+    fn auth(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        req: super::api::AuthRequest,
+        sink: ::grpcio::UnarySink<super::api::AuthResponse>,
+    );
+    fn policy(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        req: super::api::Empty,
+        sink: ::grpcio::ServerStreamingSink<super::api::InspektorPolicy>,
+    );
+    fn get_data_source(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        req: super::api::Empty,
+        sink: ::grpcio::UnarySink<super::api::DataSourceResponse>,
+    );
 }
 
 pub fn create_inspektor<S: Inspektor + Send + Clone + 'static>(s: S) -> ::grpcio::Service {
@@ -106,12 +185,14 @@ pub fn create_inspektor<S: Inspektor + Send + Clone + 'static>(s: S) -> ::grpcio
         instance.auth(ctx, req, resp)
     });
     let mut instance = s.clone();
-    builder = builder.add_server_streaming_handler(&METHOD_INSPEKTOR_POLICY, move |ctx, req, resp| {
-        instance.policy(ctx, req, resp)
-    });
+    builder = builder
+        .add_server_streaming_handler(&METHOD_INSPEKTOR_POLICY, move |ctx, req, resp| {
+            instance.policy(ctx, req, resp)
+        });
     let mut instance = s;
-    builder = builder.add_unary_handler(&METHOD_INSPEKTOR_GET_DATA_SOURCE, move |ctx, req, resp| {
-        instance.get_data_source(ctx, req, resp)
-    });
+    builder = builder
+        .add_unary_handler(&METHOD_INSPEKTOR_GET_DATA_SOURCE, move |ctx, req, resp| {
+            instance.get_data_source(ctx, req, resp)
+        });
     builder.build()
 }

--- a/src/postgres_driver/protocol_handler.rs
+++ b/src/postgres_driver/protocol_handler.rs
@@ -552,10 +552,6 @@ impl ProtocolHandler {
         schemas: Vec<String>,
     ) -> Result<(), ProtocolHandlerError> {
         debug!("input query {}", query);
-        // TODO: this needs to worked out.
-        if query.contains("BEGIN READ ONLY") {
-            return Ok(());
-        }
         let dialect = sqlparser::dialect::PostgreSqlDialect {};
         let mut statements = match sqlparser::parser::Parser::parse_sql(&dialect, query) {
             Ok(statements) => statements,
@@ -575,7 +571,7 @@ impl ProtocolHandler {
         }
         let mut out = String::from("");
         for statement in statements {
-            out = format!("{}{};", out, statement);
+            out = format!("{}{};", out, statement);    
         }
         debug!("output query {}", out);
         *query = out;

--- a/src/postgres_driver/protocol_handler.rs
+++ b/src/postgres_driver/protocol_handler.rs
@@ -570,7 +570,9 @@ impl ProtocolHandler {
         let rule = self.get_rule_engine()?;
         debug!("rewriting with schema {:?}", schemas);
         let rewriter = QueryRewriter::new(rule, schemas);
-        rewriter.rewrite(&mut statements, ctx)?;
+        for statement in &mut statements {
+            rewriter.rewrite(statement, &ctx)?;
+        }
         let mut out = String::from("");
         for statement in statements {
             out = format!("{}{};", out, statement);


### PR DESCRIPTION
Before, the inspektor will return an error if any of the statements in the query fails. But, we should forward the preceding statement. 

This PR will forward the precending statement and send the failed statement error message when the target has completed processing the preceding statement. 

close #7 