### PR TITLE
bug: reset pending error if postgres send error message

### DIFF
--- a/src/postgres_driver/protocol_handler.rs
+++ b/src/postgres_driver/protocol_handler.rs
@@ -223,6 +223,12 @@ impl ProtocolHandler {
                                             return Ok(());
                                         }
                                     },
+                                    BackendMessage::ErrorMsg(..) => {
+                                        // we should reset the error if the backend sends error message. 
+                                        // Cuz current transaction is aborted. it's upto the backend to 
+                                        // send ready for query message.
+                                        self.pending_error = None;
+                                    }
                                     _=> {}
                                 }
                             }


### PR DESCRIPTION
when client send multiple statement query, the error message for statements are kept it memory so that preceding statements
can sent to postgres. Later error message is sent to the client when the postgres finished processing. But if the postgres itself send error message, we should avoid sending the error message that kept in memory.

This PR reset the error message if the postgres send error message. 