### PR TITLE
add slack integration

### DIFF
--- a/controlplane/cmd/inspektor.go
+++ b/controlplane/cmd/inspektor.go
@@ -57,7 +57,7 @@ var rootCmd = &cobra.Command{
 		if err := policyManager.Init(); err != nil {
 			utils.Logger.Fatal("error while initializing policy manager", zap.String("err_msg", err.Error()))
 		}
-		bot := slackbot.New(config)
+		bot := slackbot.New(config, store)
 		bot.Start()
 		server := rpcserver.NewServer(store, policyManager)
 		go func(server *rpcserver.RpcServer) {

--- a/controlplane/cmd/inspektor.go
+++ b/controlplane/cmd/inspektor.go
@@ -57,8 +57,12 @@ var rootCmd = &cobra.Command{
 		if err := policyManager.Init(); err != nil {
 			utils.Logger.Fatal("error while initializing policy manager", zap.String("err_msg", err.Error()))
 		}
-		bot := slackbot.New(config, store)
-		bot.Start()
+		// start the slack bot if the config given
+		if config.SlackBotToken != "" {
+			utils.Logger.Info("starting slack bot")
+			bot := slackbot.New(config, store)
+			go bot.Start()
+		}
 		server := rpcserver.NewServer(store, policyManager)
 		go func(server *rpcserver.RpcServer) {
 			if err := server.Start(config); err != nil {

--- a/controlplane/cmd/inspektor.go
+++ b/controlplane/cmd/inspektor.go
@@ -10,6 +10,7 @@ import (
 	"inspektor/models"
 	"inspektor/policy"
 	"inspektor/rpcserver"
+	"inspektor/slackbot"
 	"inspektor/store"
 	"inspektor/utils"
 
@@ -56,6 +57,8 @@ var rootCmd = &cobra.Command{
 		if err := policyManager.Init(); err != nil {
 			utils.Logger.Fatal("error while initializing policy manager", zap.String("err_msg", err.Error()))
 		}
+		bot := slackbot.New(config)
+		bot.Start()
 		server := rpcserver.NewServer(store, policyManager)
 		go func(server *rpcserver.RpcServer) {
 			if err := server.Start(config); err != nil {

--- a/controlplane/config/config.go
+++ b/controlplane/config/config.go
@@ -3,24 +3,25 @@ package config
 import "errors"
 
 type Config struct {
-	PostgresHost      string `mapstructure:"postgres_host"`
-	PostgresPort      string `mapstructure:"postgres_port"`
-	PostgresSSL       bool   `mapstructure:"postgres_ssl"`
-	DatabaseName      string `mapstructure:"database_name"`
-	PostgresUserName  string `mapstructure:"postgres_username"`
-	PostgresPassword  string `mapstructure:"postgres_password"`
-	ListenPort        string `mapstructure:"listen_port"`
-	JwtKey            string `mapstructure:"jwt_key"`
-	GrpcListenPort    string `mapstructure:"grpc_listen_port"`
-	GithubAccessToken string `mapstructure:"github_access_token"`
-	PolicyRepo        string `mapstructure:"policy_repo"`
-	PolicyPath        string `mapstructure:"policy_path"`
-	IdpProvider       string `mapstructure:"idp_provider"`
-	IdpClientID       string `mapstructure:"idp_client_id"`
-	IdpClientSecret   string `mapstructure:"idp_client_secret"`
-	IdpServiceAccount string `mapstructure:"idp_service_account"`
-	SlackBotToken     string `mapstructure:"slack_bot_token"`
-	SlackAppToken     string `mapstructure:"slack_app_token"`
+	PostgresHost        string `mapstructure:"postgres_host"`
+	PostgresPort        string `mapstructure:"postgres_port"`
+	PostgresSSL         bool   `mapstructure:"postgres_ssl"`
+	DatabaseName        string `mapstructure:"database_name"`
+	PostgresUserName    string `mapstructure:"postgres_username"`
+	PostgresPassword    string `mapstructure:"postgres_password"`
+	ListenPort          string `mapstructure:"listen_port"`
+	JwtKey              string `mapstructure:"jwt_key"`
+	GrpcListenPort      string `mapstructure:"grpc_listen_port"`
+	GithubAccessToken   string `mapstructure:"github_access_token"`
+	PolicyRepo          string `mapstructure:"policy_repo"`
+	PolicyPath          string `mapstructure:"policy_path"`
+	IdpProvider         string `mapstructure:"idp_provider"`
+	IdpClientID         string `mapstructure:"idp_client_id"`
+	IdpClientSecret     string `mapstructure:"idp_client_secret"`
+	IdpServiceAccount   string `mapstructure:"idp_service_account"`
+	SlackBotToken       string `mapstructure:"slack_bot_token"`
+	SlackAppToken       string `mapstructure:"slack_app_token"`
+	SlackAdminChannelID string `mapstructure:"slack_admin_channel_id"`
 }
 
 func (c *Config) Validate() error {

--- a/controlplane/config/config.go
+++ b/controlplane/config/config.go
@@ -55,5 +55,8 @@ func (c *Config) Validate() error {
 	if c.SlackBotToken != "" && c.SlackAppToken == "" {
 		return errors.New("slack integration requires slack bot token and slack app token")
 	}
+	if c.SlackBotToken != "" && c.SlackAdminChannelID == "" {
+		return errors.New("slack integration requires one channel id for to send approval request")
+	}
 	return nil
 }

--- a/controlplane/config/config.go
+++ b/controlplane/config/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	IdpClientID       string `mapstructure:"idp_client_id"`
 	IdpClientSecret   string `mapstructure:"idp_client_secret"`
 	IdpServiceAccount string `mapstructure:"idp_service_account"`
+	SlackBotToken     string `mapstructure:"slack_bot_token"`
+	SlackAppToken     string `mapstructure:"slack_app_token"`
 }
 
 func (c *Config) Validate() error {
@@ -48,6 +50,9 @@ func (c *Config) Validate() error {
 	}
 	if c.PolicyPath == "" {
 		c.PolicyPath = "./policy_dir"
+	}
+	if c.SlackBotToken != "" && c.SlackAppToken == "" {
+		return errors.New("slack integration requires slack bot token and slack app token")
 	}
 	return nil
 }

--- a/controlplane/go.mod
+++ b/controlplane/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/open-policy-agent/opa v0.34.2
 	github.com/shurcooL/githubv4 v0.0.0-20220115235240-a14260e6f8a2
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
+	github.com/slack-go/slack v0.10.2 // indirect
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 	go.uber.org/zap v1.19.1

--- a/controlplane/go.sum
+++ b/controlplane/go.sum
@@ -150,6 +150,7 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -245,6 +246,8 @@ github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -461,6 +464,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/slack-go/slack v0.10.2 h1:KMN/h2sgUninHXvQI8PrR/PHBUuWp2NPvz2Kr66tki4=
+github.com/slack-go/slack v0.10.2/go.mod h1:5FLdBRv7VW/d9EBxx/eEktOptWygbA9K2QK/KW7ds1s=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=

--- a/controlplane/models/session.go
+++ b/controlplane/models/session.go
@@ -18,11 +18,13 @@ type Session struct {
 }
 
 type SessionMeta struct {
-	Type             string   `json:"type"`
-	PostgresPassword string   `json:"postgresPassword"`
-	PostgresUsername string   `json:"postgresUsername"`
-	TempRoles        []string `json:"tempRoles"`
-	ExpiresAt        int64    `json:"expiresAt"`
+	Type             string          `json:"type"`
+	PostgresPassword string          `json:"postgresPassword"`
+	PostgresUsername string          `json:"postgresUsername"`
+	TempRoles        []string        `json:"tempRoles"`
+	ExpiresAt        int64           `json:"expiresAt"`
+	Context          json.RawMessage `json:"context"`
+	TempCreatedBy    string          `json:"tempCreatedBy"`
 }
 
 func (s *Session) UnmarshalMeta() {

--- a/controlplane/slackbot/slack.go
+++ b/controlplane/slackbot/slack.go
@@ -17,7 +17,9 @@ package slackbot
 import (
 	"fmt"
 	"inspektor/config"
+	"inspektor/store"
 	"inspektor/utils"
+	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/slack-go/slack"
@@ -27,20 +29,25 @@ import (
 )
 
 type AccessRequest struct {
-	UserID string
+	UserID   string
+	database uint
+	Roles    []string
 }
 type SlackBot struct {
 	client          *slack.Client
 	adminChannelID  string
 	pendingRequests map[string]AccessRequest
+	store           *store.Store
 }
 
-func New(cfg *config.Config) *SlackBot {
+func New(cfg *config.Config, store *store.Store) *SlackBot {
 	client := slack.New(cfg.SlackBotToken,
 		slack.OptionAppLevelToken(cfg.SlackAppToken), slack.OptionDebug(true))
 	return &SlackBot{
-		client:         client,
-		adminChannelID: cfg.SlackAdminChannelID,
+		client:          client,
+		adminChannelID:  cfg.SlackAdminChannelID,
+		store:           store,
+		pendingRequests: make(map[string]AccessRequest),
 	}
 }
 
@@ -66,16 +73,51 @@ func (s *SlackBot) Start() {
 					for _, cb := range interactiveEvent.ActionCallback.BlockActions {
 						switch cb.ActionID {
 						case "request-access":
-							databases := NewBlockOptions([]string{"databases"}, []string{"databases"})
-							roles := NewBlockOptions([]string{"admin", "dev"}, []string{"admin", "dev"})
-							_, err := s.client.OpenView(interactiveEvent.TriggerID,
-								NewRequestAccessModal(uuid.NewString(), databases, roles))
+							datasources, err := s.store.GetDataSource()
+							if err != nil {
+								utils.Logger.Error("error while retriving all the datasources", zap.String("err_msg", err.Error()))
+								continue
+							}
+							databaseNames := []string{}
+							databaseIDs := []string{}
+							for _, datasource := range datasources {
+								databaseNames = append(databaseNames, datasource.Name)
+								databaseIDs = append(databaseIDs, fmt.Sprintf("%d", datasource.ID))
+							}
+							databases := NewBlockOptions(databaseNames, databaseIDs)
+							roles, err := s.store.GetRoles()
+							if err != nil {
+								utils.Logger.Error("error while retriving roles", zap.String("err_msg", err.Error()))
+								continue
+							}
+							rolesBlock := NewBlockOptions(roles, roles)
+							modalView := NewRequestAccessModal(uuid.NewString(), databases, rolesBlock)
+							fmt.Print("\n\n\n\n")
+							fmt.Println(string(utils.MarshalJSON(modalView)))
+							_, err = s.client.OpenView(interactiveEvent.TriggerID, modalView)
 							if err != nil {
 								utils.Logger.Error("error while opening modal view", zap.String("err_msg", err.Error()))
 							}
 							fmt.Println("modal triggered")
-						default:
+						case "denied":
 							socketClient.Ack(*event.Request)
+							_, _, err := s.client.PostMessage(s.adminChannelID, slack.MsgOptionText("We'll let them know that the request has been denied", false))
+							if err != nil {
+								utils.Logger.Error("error while approval message to the admin", zap.String("err_msg", err.Error()))
+							}
+						case "approved":
+							socketClient.Ack(*event.Request)
+							accessRequest, ok := s.pendingRequests[interactiveEvent.View.CallbackID]
+							if !ok {
+								_, _, err := s.client.PostMessage(s.adminChannelID, slack.MsgOptionText("Unable to find the request", false))
+								if err != nil {
+									utils.Logger.Error("error while approval message to the admin", zap.String("err_msg", err.Error()))
+								}
+								continue
+							}
+							// apporve request
+							fmt.Println(accessRequest)
+							// send credentials.
 							_, _, err := s.client.PostMessage(s.adminChannelID, slack.MsgOptionText("Thanks for approving. Credentials will be sent to the user", false))
 							if err != nil {
 								utils.Logger.Error("error while approval message to the admin", zap.String("err_msg", err.Error()))
@@ -99,15 +141,29 @@ func (s *SlackBot) Start() {
 					}
 					socketClient.Ack(*event.Request)
 					fmt.Println("selected database", databaseState.SelectedOption.Value)
+					selectedDatabase, err := strconv.Atoi(databaseState.SelectedOption.Value)
+					if err != nil {
+						utils.Logger.Error("error while parsinsg database id", zap.String("err_msg", err.Error()))
+						continue
+					}
+					selectedRoles := []string{}
+					for _, option := range rolesState.SelectedOptions {
+						selectedRoles = append(selectedRoles, option.Value)
+					}
 					fmt.Println("selected roles", rolesState.SelectedOptions)
-					_, err := s.client.PublishView(interactiveEvent.User.ID, NewRequestSentView(), "")
+					_, err = s.client.PublishView(interactiveEvent.User.ID, NewRequestSentView(), "")
 					if err != nil {
 						utils.Logger.Error("error while publishing request sent view", zap.String("err_msg", err.Error()))
 					}
 					_, _, err = s.client.PostMessage(s.adminChannelID,
-						slack.MsgOptionBlocks(NewRequestAccessMsg("ppoami", "postgres", []string{"admin", "dev"})...))
+						slack.MsgOptionBlocks(NewRequestAccessMsg(interactiveEvent.User.ID, databaseState.SelectedOption.Text.Text, selectedRoles, interactiveEvent.View.CallbackID)...))
 					if err != nil {
 						utils.Logger.Error("error while sending approval message", zap.String("err_msg", err.Error()))
+					}
+					s.pendingRequests[interactiveEvent.View.CallbackID] = AccessRequest{
+						UserID:   interactiveEvent.User.ID,
+						database: uint(selectedDatabase),
+						Roles:    selectedRoles,
 					}
 				}
 

--- a/controlplane/slackbot/slack.go
+++ b/controlplane/slackbot/slack.go
@@ -1,0 +1,92 @@
+// Copyright 2022 poonai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slackbot
+
+import (
+	"fmt"
+	"inspektor/config"
+	"inspektor/utils"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+	"go.uber.org/zap"
+)
+
+type SlackBot struct {
+	client *slack.Client
+}
+
+func New(cfg *config.Config) *SlackBot {
+	client := slack.New(cfg.SlackBotToken,
+		slack.OptionAppLevelToken(cfg.SlackAppToken), slack.OptionDebug(true))
+	return &SlackBot{
+		client: client,
+	}
+}
+
+func (s *SlackBot) Start() {
+	socketClient := socketmode.New(s.client, socketmode.OptionDebug(true))
+	go func() {
+		fmt.Println("socket listen")
+		for event := range socketClient.Events {
+			switch event.Type {
+			case socketmode.EventTypeEventsAPI:
+				event, ok := event.Data.(*slackevents.EventsAPIEvent)
+				if !ok {
+					utils.Logger.Error("unexpected slack event api event")
+					continue
+				}
+				s.handleEventApi(event.Data)
+			default:
+				utils.Logger.Debug("skipping slack event", zap.String("event_name", string(event.Type)))
+			}
+		}
+	}()
+	socketClient.Run()
+}
+
+func (s *SlackBot) handleEventApi(data interface{}) {
+	switch event := data.(type) {
+	case *slackevents.AppHomeOpenedEvent:
+		fmt.Println("publishing vent")
+		res, err := s.client.PublishView(event.User, slack.HomeTabViewRequest{
+			Type: slack.VTHomeTab,
+			Blocks: slack.Blocks{[]slack.Block{
+				slack.ActionBlock{
+					Elements: &slack.BlockElements{
+						[]slack.BlockElement{
+							slack.ButtonBlockElement{
+								Type: slack.METButton,
+								Text: &slack.TextBlockObject{
+									Type: slack.PlainTextType,
+									Text: "Request Access",
+								},
+							},
+						},
+					},
+				},
+			}},
+			PrivateMetadata: "",
+			CallbackID:      "",
+			ExternalID:      "",
+		}, "")
+		if err != nil {
+			utils.Logger.Error("error whule publishing view", zap.String("err_msg", err.Error()))
+			return
+		}
+		utils.Logger.Debug("view response", zap.String("res", string(utils.MarshalJSON(res))))
+	}
+}

--- a/controlplane/slackbot/slack.go
+++ b/controlplane/slackbot/slack.go
@@ -19,28 +19,34 @@ import (
 	"inspektor/config"
 	"inspektor/utils"
 
+	"github.com/google/uuid"
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
 	"github.com/slack-go/slack/socketmode"
 	"go.uber.org/zap"
 )
 
+type AccessRequest struct {
+	UserID string
+}
 type SlackBot struct {
-	client *slack.Client
+	client          *slack.Client
+	adminChannelID  string
+	pendingRequests map[string]AccessRequest
 }
 
 func New(cfg *config.Config) *SlackBot {
 	client := slack.New(cfg.SlackBotToken,
 		slack.OptionAppLevelToken(cfg.SlackAppToken), slack.OptionDebug(true))
 	return &SlackBot{
-		client: client,
+		client:         client,
+		adminChannelID: cfg.SlackAdminChannelID,
 	}
 }
 
 func (s *SlackBot) Start() {
 	socketClient := socketmode.New(s.client, socketmode.OptionDebug(true))
 	go func() {
-		fmt.Println("socket listen")
 		for event := range socketClient.Events {
 			switch event.Type {
 			case socketmode.EventTypeEventsAPI:
@@ -51,11 +57,60 @@ func (s *SlackBot) Start() {
 				}
 				s.handleEventApi(event.InnerEvent)
 			case socketmode.EventTypeInteractive:
-				action, ok := event.Data.(slack.InteractionCallback)
+				interactiveEvent, ok := event.Data.(slack.InteractionCallback)
 				if !ok {
 					continue
 				}
-				s.handleActionCB(action.ActionCallback, action.TriggerID)
+				switch interactiveEvent.Type {
+				case slack.InteractionTypeBlockActions:
+					for _, cb := range interactiveEvent.ActionCallback.BlockActions {
+						switch cb.ActionID {
+						case "request-access":
+							databases := NewBlockOptions([]string{"databases"}, []string{"databases"})
+							roles := NewBlockOptions([]string{"admin", "dev"}, []string{"admin", "dev"})
+							_, err := s.client.OpenView(interactiveEvent.TriggerID,
+								NewRequestAccessModal(uuid.NewString(), databases, roles))
+							if err != nil {
+								utils.Logger.Error("error while opening modal view", zap.String("err_msg", err.Error()))
+							}
+							fmt.Println("modal triggered")
+						default:
+							socketClient.Ack(*event.Request)
+							_, _, err := s.client.PostMessage(s.adminChannelID, slack.MsgOptionText("Thanks for approving. Credentials will be sent to the user", false))
+							if err != nil {
+								utils.Logger.Error("error while approval message to the admin", zap.String("err_msg", err.Error()))
+							}
+						}
+					}
+				case slack.InteractionTypeViewSubmission:
+					fmt.Println("callback id ", interactiveEvent.View.CallbackID)
+					fmt.Println("raw state\n\n\n")
+					fmt.Println(interactiveEvent.RawState)
+					fmt.Printf("%+v", interactiveEvent.View.State.Values)
+					databaseState, ok := interactiveEvent.View.State.Values["databaseblock"]["database"]
+					if !ok {
+						utils.Logger.Error("unable to find databaseblock on view submission")
+						continue
+					}
+					rolesState, ok := interactiveEvent.View.State.Values["rolesblock"]["roles"]
+					if !ok {
+						utils.Logger.Error("unable to find rolesblock on view submission")
+						continue
+					}
+					socketClient.Ack(*event.Request)
+					fmt.Println("selected database", databaseState.SelectedOption.Value)
+					fmt.Println("selected roles", rolesState.SelectedOptions)
+					_, err := s.client.PublishView(interactiveEvent.User.ID, NewRequestSentView(), "")
+					if err != nil {
+						utils.Logger.Error("error while publishing request sent view", zap.String("err_msg", err.Error()))
+					}
+					_, _, err = s.client.PostMessage(s.adminChannelID,
+						slack.MsgOptionBlocks(NewRequestAccessMsg("ppoami", "postgres", []string{"admin", "dev"})...))
+					if err != nil {
+						utils.Logger.Error("error while sending approval message", zap.String("err_msg", err.Error()))
+					}
+				}
+
 			default:
 				utils.Logger.Debug("skipping slack event", zap.String("event_name", string(event.Type)))
 			}
@@ -64,188 +119,17 @@ func (s *SlackBot) Start() {
 	socketClient.Run()
 }
 
-func (s *SlackBot) handleActionCB(cbs slack.ActionCallbacks, triggerID string) {
-	for _, cb := range cbs.BlockActions {
-		switch cb.ActionID {
-		case "request-access":
-			_, err := s.client.OpenView(triggerID, slack.ModalViewRequest{
-				Type: slack.VTModal,
-				Title: &slack.TextBlockObject{
-					Type: slack.PlainTextType,
-					Text: "Request Temporary Access",
-				},
-				Submit: &slack.TextBlockObject{
-					Type: slack.PlainTextType,
-					Text: "Request Access",
-				},
-				Close: &slack.TextBlockObject{
-					Type: slack.PlainTextType,
-					Text: "Cancel",
-				},
-				Blocks: slack.Blocks{
-					BlockSet: []slack.Block{
-						slack.SectionBlock{
-							Type: slack.MBTSection,
-							Text: &slack.TextBlockObject{
-								Type: slack.PlainTextType,
-								Text: "Select database you wish to access",
-							},
-							Accessory: &slack.Accessory{
-								SelectElement: &slack.SelectBlockElement{
-									Type: slack.OptTypeStatic,
-									Placeholder: &slack.TextBlockObject{
-										Type: slack.PlainTextType,
-										Text: "Select a Database",
-									},
-									Options: []*slack.OptionBlockObject{
-										&slack.OptionBlockObject{
-											Text: &slack.TextBlockObject{
-												Type: slack.PlainTextType,
-												Text: "postgres-prod",
-											},
-											Value: "postgres-prod",
-										},
-										&slack.OptionBlockObject{
-											Text: &slack.TextBlockObject{
-												Type: slack.PlainTextType,
-												Text: "postgres-prod1",
-											},
-											Value: "postgres-prod1",
-										},
-										&slack.OptionBlockObject{
-											Text: &slack.TextBlockObject{
-												Type: slack.PlainTextType,
-												Text: "postgres-prod2",
-											},
-											Value: "postgres-prod2",
-										},
-									},
-								},
-							},
-						},
-						slack.SectionBlock{
-							Type: slack.MBTSection,
-							Text: &slack.TextBlockObject{
-								Type: slack.PlainTextType,
-								Text: "Select roles you wish to obtain",
-							},
-							Accessory: &slack.Accessory{
-								SelectElement: &slack.SelectBlockElement{
-									Type: slack.MultiOptTypeStatic,
-									Placeholder: &slack.TextBlockObject{
-										Type: slack.PlainTextType,
-										Text: "Select roles",
-									},
-									Options: []*slack.OptionBlockObject{
-										&slack.OptionBlockObject{
-											Text: &slack.TextBlockObject{
-												Type: slack.PlainTextType,
-												Text: "admin",
-											},
-											Value: "admin",
-										},
-										&slack.OptionBlockObject{
-											Text: &slack.TextBlockObject{
-												Type: slack.PlainTextType,
-												Text: "support",
-											},
-											Value: "support",
-										},
-										&slack.OptionBlockObject{
-											Text: &slack.TextBlockObject{
-												Type: slack.PlainTextType,
-												Text: "dev",
-											},
-											Value: "dev",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			})
-			if err != nil {
-				utils.Logger.Error("error while opening modal view", zap.String("err_msg", err.Error()))
-			}
-			fmt.Println("modal triggered")
-		}
-	}
-}
-
 func (s *SlackBot) handleEventApi(data interface{}) {
-	fmt.Println("event api\n\n\n\n\n\n\n\n\n\n\n\n\n")
-	fmt.Println(string(utils.MarshalJSON(data)))
 	switch event := data.(type) {
 	case slackevents.EventsAPIInnerEvent:
 		innerEvent, ok := event.Data.(*slackevents.AppHomeOpenedEvent)
 		if !ok {
 			return
 		}
-		fmt.Println("publishing vent")
-		// {
-		// 	"blocks": [
-		// 		{
-		// 			"type": "section",
-		// 			"text": {
-		// 				"type": "mrkdwn",
-		// 				"text": "Hi👋, I'm Inspektor bot 🤖. you can request for \n database access through me"
-		// 			},
-		// 			"accessory": {
-		// 				"type": "button",
-		// 				"text": {
-		// 					"type": "plain_text",
-		// 					"text": "Request Access",
-		// 					"emoji": true
-		// 				},
-		// 				"value": "click_me_123",
-		// 				"action_id": "button-action"
-		// 			}
-		// 		}
-		// 	]
-		// }
-		// slack.ActionBlock{
-		// 	Type: slack.MBTAction,
-		// 	Elements: &slack.BlockElements{
-		// 		[]slack.BlockElement{
-		// 			slack.ButtonBlockElement{
-		// 				Type: slack.METButton,
-		// 				Text: &slack.TextBlockObject{
-		// 					Type: slack.PlainTextType,
-		// 					Text: "Request Access",
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		res, err := s.client.PublishView(innerEvent.User, slack.HomeTabViewRequest{
-			Type: slack.VTHomeTab,
-			Blocks: slack.Blocks{[]slack.Block{
-				slack.SectionBlock{
-					Type: slack.MBTSection,
-					Text: &slack.TextBlockObject{
-						Type: slack.MarkdownType,
-						Text: "Hi👋, I'm Inspektor bot 🤖. you can request for database access through me",
-					},
-					Accessory: &slack.Accessory{
-						ButtonElement: &slack.ButtonBlockElement{
-							Type: slack.METButton,
-							Text: &slack.TextBlockObject{
-								Type:  slack.PlainTextType,
-								Text:  "Request Access",
-								Emoji: true,
-							},
-							Value:    "access_requested",
-							ActionID: "request-access",
-						},
-					},
-				},
-			}},
-		}, "")
+		_, err := s.client.PublishView(innerEvent.User, NewHomeTabView(), "")
 		if err != nil {
-			utils.Logger.Error("error whule publishing view", zap.String("err_msg", err.Error()))
+			utils.Logger.Error("error while publishing view", zap.String("err_msg", err.Error()))
 			return
 		}
-		utils.Logger.Debug("view response", zap.String("res", string(utils.MarshalJSON(res))))
 	}
 }

--- a/controlplane/slackbot/slack.go
+++ b/controlplane/slackbot/slack.go
@@ -29,7 +29,7 @@ import (
 )
 
 type AccessRequest struct {
-	UserID   string
+	User     *slack.User
 	database uint
 	Roles    []string
 }
@@ -38,11 +38,13 @@ type SlackBot struct {
 	adminChannelID  string
 	pendingRequests map[string]AccessRequest
 	store           *store.Store
+	socketClient    *socketmode.Client
 }
 
+// New will return slack bot.
 func New(cfg *config.Config, store *store.Store) *SlackBot {
 	client := slack.New(cfg.SlackBotToken,
-		slack.OptionAppLevelToken(cfg.SlackAppToken), slack.OptionDebug(true))
+		slack.OptionAppLevelToken(cfg.SlackAppToken), slack.OptionDebug(false))
 	return &SlackBot{
 		client:          client,
 		adminChannelID:  cfg.SlackAdminChannelID,
@@ -51,10 +53,12 @@ func New(cfg *config.Config, store *store.Store) *SlackBot {
 	}
 }
 
+// Start will start listening for websocket event and handles all the interative events.
+// eg: request submission and credentials delivery.
 func (s *SlackBot) Start() {
-	socketClient := socketmode.New(s.client, socketmode.OptionDebug(true))
+	s.socketClient = socketmode.New(s.client, socketmode.OptionDebug(false))
 	go func() {
-		for event := range socketClient.Events {
+		for event := range s.socketClient.Events {
 			switch event.Type {
 			case socketmode.EventTypeEventsAPI:
 				event, ok := event.Data.(slackevents.EventsAPIEvent)
@@ -71,100 +75,12 @@ func (s *SlackBot) Start() {
 				switch interactiveEvent.Type {
 				case slack.InteractionTypeBlockActions:
 					for _, cb := range interactiveEvent.ActionCallback.BlockActions {
-						switch cb.ActionID {
-						case "request-access":
-							datasources, err := s.store.GetDataSource()
-							if err != nil {
-								utils.Logger.Error("error while retriving all the datasources", zap.String("err_msg", err.Error()))
-								continue
-							}
-							databaseNames := []string{}
-							databaseIDs := []string{}
-							for _, datasource := range datasources {
-								databaseNames = append(databaseNames, datasource.Name)
-								databaseIDs = append(databaseIDs, fmt.Sprintf("%d", datasource.ID))
-							}
-							databases := NewBlockOptions(databaseNames, databaseIDs)
-							roles, err := s.store.GetRoles()
-							if err != nil {
-								utils.Logger.Error("error while retriving roles", zap.String("err_msg", err.Error()))
-								continue
-							}
-							rolesBlock := NewBlockOptions(roles, roles)
-							modalView := NewRequestAccessModal(uuid.NewString(), databases, rolesBlock)
-							fmt.Print("\n\n\n\n")
-							fmt.Println(string(utils.MarshalJSON(modalView)))
-							_, err = s.client.OpenView(interactiveEvent.TriggerID, modalView)
-							if err != nil {
-								utils.Logger.Error("error while opening modal view", zap.String("err_msg", err.Error()))
-							}
-							fmt.Println("modal triggered")
-						case "denied":
-							socketClient.Ack(*event.Request)
-							_, _, err := s.client.PostMessage(s.adminChannelID, slack.MsgOptionText("We'll let them know that the request has been denied", false))
-							if err != nil {
-								utils.Logger.Error("error while approval message to the admin", zap.String("err_msg", err.Error()))
-							}
-						case "approved":
-							socketClient.Ack(*event.Request)
-							accessRequest, ok := s.pendingRequests[interactiveEvent.View.CallbackID]
-							if !ok {
-								_, _, err := s.client.PostMessage(s.adminChannelID, slack.MsgOptionText("Unable to find the request", false))
-								if err != nil {
-									utils.Logger.Error("error while approval message to the admin", zap.String("err_msg", err.Error()))
-								}
-								continue
-							}
-							// apporve request
-							fmt.Println(accessRequest)
-							// send credentials.
-							_, _, err := s.client.PostMessage(s.adminChannelID, slack.MsgOptionText("Thanks for approving. Credentials will be sent to the user", false))
-							if err != nil {
-								utils.Logger.Error("error while approval message to the admin", zap.String("err_msg", err.Error()))
-							}
-						}
+						s.socketClient.Ack(*event.Request)
+						s.handleAction(cb, interactiveEvent)
 					}
 				case slack.InteractionTypeViewSubmission:
-					fmt.Println("callback id ", interactiveEvent.View.CallbackID)
-					fmt.Println("raw state\n\n\n")
-					fmt.Println(interactiveEvent.RawState)
-					fmt.Printf("%+v", interactiveEvent.View.State.Values)
-					databaseState, ok := interactiveEvent.View.State.Values["databaseblock"]["database"]
-					if !ok {
-						utils.Logger.Error("unable to find databaseblock on view submission")
-						continue
-					}
-					rolesState, ok := interactiveEvent.View.State.Values["rolesblock"]["roles"]
-					if !ok {
-						utils.Logger.Error("unable to find rolesblock on view submission")
-						continue
-					}
-					socketClient.Ack(*event.Request)
-					fmt.Println("selected database", databaseState.SelectedOption.Value)
-					selectedDatabase, err := strconv.Atoi(databaseState.SelectedOption.Value)
-					if err != nil {
-						utils.Logger.Error("error while parsinsg database id", zap.String("err_msg", err.Error()))
-						continue
-					}
-					selectedRoles := []string{}
-					for _, option := range rolesState.SelectedOptions {
-						selectedRoles = append(selectedRoles, option.Value)
-					}
-					fmt.Println("selected roles", rolesState.SelectedOptions)
-					_, err = s.client.PublishView(interactiveEvent.User.ID, NewRequestSentView(), "")
-					if err != nil {
-						utils.Logger.Error("error while publishing request sent view", zap.String("err_msg", err.Error()))
-					}
-					_, _, err = s.client.PostMessage(s.adminChannelID,
-						slack.MsgOptionBlocks(NewRequestAccessMsg(interactiveEvent.User.ID, databaseState.SelectedOption.Text.Text, selectedRoles, interactiveEvent.View.CallbackID)...))
-					if err != nil {
-						utils.Logger.Error("error while sending approval message", zap.String("err_msg", err.Error()))
-					}
-					s.pendingRequests[interactiveEvent.View.CallbackID] = AccessRequest{
-						UserID:   interactiveEvent.User.ID,
-						database: uint(selectedDatabase),
-						Roles:    selectedRoles,
-					}
+					s.socketClient.Ack(*event.Request)
+					s.handleRequestSubmission(interactiveEvent)
 				}
 
 			default:
@@ -172,9 +88,10 @@ func (s *SlackBot) Start() {
 			}
 		}
 	}()
-	socketClient.Run()
+	s.socketClient.Run()
 }
 
+// handleEventApi shows entry point for the user to intiate request access.
 func (s *SlackBot) handleEventApi(data interface{}) {
 	switch event := data.(type) {
 	case slackevents.EventsAPIInnerEvent:
@@ -187,5 +104,134 @@ func (s *SlackBot) handleEventApi(data interface{}) {
 			utils.Logger.Error("error while publishing view", zap.String("err_msg", err.Error()))
 			return
 		}
+	}
+}
+
+// handleRequestSubmission will handle the form submission event. We do get this event only if
+// the user submitted request access modal.
+func (s *SlackBot) handleRequestSubmission(iEvent slack.InteractionCallback) {
+	// retrive the value of datsource id and roles which they want to gain.
+	databaseState, ok := iEvent.View.State.Values["databaseblock"]["database"]
+	if !ok {
+		utils.Logger.Error("unable to find databaseblock on view submission")
+		return
+	}
+	rolesState, ok := iEvent.View.State.Values["rolesblock"]["roles"]
+	if !ok {
+		utils.Logger.Error("unable to find rolesblock on view submission")
+		return
+	}
+	selectedDatabase, err := strconv.Atoi(databaseState.SelectedOption.Value)
+	if err != nil {
+		utils.Logger.Error("error while parsinsg database id", zap.String("err_msg", err.Error()))
+		return
+	}
+	selectedRoles := []string{}
+	for _, option := range rolesState.SelectedOptions {
+		selectedRoles = append(selectedRoles, option.Value)
+	}
+
+	// track the request in the memory, so if the admin approve we can map the approval
+	// with the request and can send credentials to the user.
+	user, err := s.client.GetUserInfo(iEvent.User.ID)
+	if err != nil {
+		utils.Logger.Error("error while retriving user details", zap.String("err_msg", err.Error()))
+		return
+	}
+	s.pendingRequests[iEvent.View.CallbackID] = AccessRequest{
+		User:     user,
+		database: uint(selectedDatabase),
+		Roles:    selectedRoles,
+	}
+	// send approval view for the admin to approve or deny the request.
+	_, err = s.client.PublishView(iEvent.User.ID, NewRequestSentView(), "")
+	if err != nil {
+		utils.Logger.Error("error while publishing request sent view", zap.String("err_msg", err.Error()))
+	}
+	_, _, err = s.client.PostMessage(s.adminChannelID,
+		slack.MsgOptionBlocks(NewRequestAccessMsg(user.Name, databaseState.SelectedOption.Text.Text, selectedRoles, iEvent.View.CallbackID)...))
+	if err != nil {
+		utils.Logger.Error("error while sending approval message", zap.String("err_msg", err.Error()))
+	}
+
+}
+
+func (s *SlackBot) handleAction(action *slack.BlockAction, iEvent slack.InteractionCallback) {
+	switch action.ActionID {
+	case "request-access":
+		// access has been requested. So, open a modal where user can choose
+		// the database and roles which they want to gain.
+		datasources, err := s.store.GetDataSource()
+		if err != nil {
+			utils.Logger.Error("error while retriving all the datasources", zap.String("err_msg", err.Error()))
+			return
+		}
+		databaseNames := []string{}
+		databaseIDs := []string{}
+		for _, datasource := range datasources {
+			databaseNames = append(databaseNames, datasource.Name)
+			databaseIDs = append(databaseIDs, fmt.Sprintf("%d", datasource.ID))
+		}
+		roles, err := s.store.GetRoles()
+		if err != nil {
+			utils.Logger.Error("error while retriving roles", zap.String("err_msg", err.Error()))
+			return
+		}
+
+		// create the modal view for the user.
+		rolesBlock := NewBlockOptions(roles, roles)
+		databases := NewBlockOptions(databaseNames, databaseIDs)
+		modalView := NewRequestAccessModal(uuid.NewString(), databases, rolesBlock)
+		_, err = s.client.OpenView(iEvent.TriggerID, modalView)
+		if err != nil {
+			utils.Logger.Error("error while opening modal view", zap.String("err_msg", err.Error()))
+		}
+	case "denied":
+		// request has been denied, so let the requested user know that the request has been
+		// denied.
+		s.postMessage(s.adminChannelID, "We'll let them know that the request has been denied")
+		accessRequest, ok := s.pendingRequests[action.Value]
+		if !ok {
+			return
+		}
+		s.postMessage(accessRequest.User.ID, "Your access request has been denied")
+	case "approved":
+		// request has been approved, so create the temp session and send the credentials as direct message
+		// to the requested user.
+		accessRequest, ok := s.pendingRequests[action.Value]
+		if !ok {
+			_, _, err := s.client.PostMessage(s.adminChannelID, slack.MsgOptionText("Unable to find the request", false))
+			if err != nil {
+				utils.Logger.Error("error while approval message to the admin", zap.String("err_msg", err.Error()))
+			}
+			return
+		}
+		session, err := s.store.CreateTempSession(accessRequest.database, accessRequest.Roles, 10, "slack", utils.MarshalJSON(accessRequest.User))
+		if err != nil {
+			utils.Logger.Error("error while creating temp credentials", zap.String("err_msg", err.Error()))
+			return
+		}
+		datasource, err := s.store.GetDatasource(accessRequest.database)
+		if err != nil {
+			utils.Logger.Error("error while retirving datasource", zap.String("err_msg", err.Error()))
+			s.postMessage(s.adminChannelID, "unable to retrive datasoruce information")
+			return
+		}
+		credentialBlock := NewCredentialsBlock(session.SessionMeta.PostgresUsername, session.SessionMeta.PostgresPassword, datasource.SideCarHostName)
+		_, _, err = s.client.PostMessage(accessRequest.User.ID, slack.MsgOptionBlocks(credentialBlock...))
+		if err != nil {
+			utils.Logger.Error("error while sending credentials to the user")
+			s.postMessage(s.adminChannelID, "error while sending credentials to the user")
+			return
+		}
+		s.postMessage(s.adminChannelID, "Thanks for approving. Credentials will be sent to the user")
+	}
+}
+
+// postMessage will send plain text message to the given channel id.
+func (s *SlackBot) postMessage(channelID string, msg string) {
+	_, _, err := s.client.PostMessage(channelID, slack.MsgOptionText(msg, false))
+	if err != nil {
+		utils.Logger.Error("error while approval message to the admin", zap.String("err_msg", err.Error()))
 	}
 }

--- a/controlplane/slackbot/views.go
+++ b/controlplane/slackbot/views.go
@@ -1,0 +1,242 @@
+// Copyright 2022 poonai
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slackbot
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/slack-go/slack"
+)
+
+func NewRequestAccessModal(requestID string, databases []*slack.OptionBlockObject,
+	roles []*slack.OptionBlockObject) slack.ModalViewRequest {
+	return slack.ModalViewRequest{
+		Type: slack.VTModal,
+		Title: &slack.TextBlockObject{
+			Type: slack.PlainTextType,
+			Text: "Request Temporary Access",
+		},
+		Submit: &slack.TextBlockObject{
+			Type: slack.PlainTextType,
+			Text: "Request Access",
+		},
+		Close: &slack.TextBlockObject{
+			Type: slack.PlainTextType,
+			Text: "Cancel",
+		},
+		CallbackID: requestID,
+		Blocks: slack.Blocks{
+			BlockSet: []slack.Block{
+				slack.InputBlock{
+					BlockID: "databaseblock",
+					Type:    slack.MBTInput,
+					Element: slack.SelectBlockElement{
+						Type:        slack.OptTypeStatic,
+						Placeholder: slack.NewTextBlockObject(slack.PlainTextType, "slect database", false, false),
+						Options:     databases,
+						ActionID:    "database",
+					},
+					Label: &slack.TextBlockObject{
+						Type: slack.PlainTextType,
+						Text: "Selete database",
+					},
+				},
+				slack.InputBlock{
+					BlockID: "rolesblock",
+					Type:    slack.MBTInput,
+					Element: slack.SelectBlockElement{
+						Type:        slack.MultiOptTypeStatic,
+						Placeholder: slack.NewTextBlockObject(slack.PlainTextType, "slect database", false, false),
+						Options:     roles,
+						ActionID:    "roles",
+					},
+					Label: &slack.TextBlockObject{
+						Type: slack.PlainTextType,
+						Text: "Selete roles",
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewRequestSentView() slack.HomeTabViewRequest {
+	return slack.HomeTabViewRequest{
+		Type: slack.VTHomeTab,
+		Blocks: slack.Blocks{
+			BlockSet: []slack.Block{
+				slack.SectionBlock{
+					Type: slack.MBTSection,
+					Text: slack.NewTextBlockObject(slack.PlainTextType, "Your request have sent to admin for approval✌️", false, false),
+				},
+			},
+		},
+	}
+}
+
+func NewBlockOptions(options []string, values []string) []*slack.OptionBlockObject {
+	opts := []*slack.OptionBlockObject{}
+	for i, option := range options {
+		opts = append(opts, &slack.OptionBlockObject{
+			Text:  slack.NewTextBlockObject(slack.PlainTextType, option, false, false),
+			Value: values[i],
+		})
+	}
+	return opts
+}
+
+func NewHomeTabView() slack.HomeTabViewRequest {
+	return slack.HomeTabViewRequest{
+		Type: slack.VTHomeTab,
+		Blocks: slack.Blocks{[]slack.Block{
+			slack.SectionBlock{
+				Type: slack.MBTSection,
+				Text: &slack.TextBlockObject{
+					Type: slack.MarkdownType,
+					Text: "Hi👋, I'm Inspektor bot 🤖. you can request for database access through me",
+				},
+				Accessory: &slack.Accessory{
+					ButtonElement: &slack.ButtonBlockElement{
+						Type: slack.METButton,
+						Text: &slack.TextBlockObject{
+							Type:  slack.PlainTextType,
+							Text:  "Request Access",
+							Emoji: true,
+						},
+						Value:    "access_requested",
+						ActionID: "request-access",
+					},
+				},
+			},
+		}},
+	}
+}
+
+// credentials approved block
+// {
+// 	"blocks": [
+// 		{
+// 			"type": "section",
+// 			"text": {
+// 				"type": "mrkdwn",
+// 				"text": "Your access have approved. credentials can be found below"
+// 			}
+// 		},
+// 		{
+// 			"type": "section",
+// 			"fields": [
+// 				{
+// 					"type": "mrkdwn",
+// 					"text": "*Username:*\n postgresprod"
+// 				},
+// 				{
+// 					"type": "mrkdwn",
+// 					"text": "*Password:*\nadmin, deve, support"
+// 				},
+// 				{
+// 					"type": "mrkdwn",
+// 					"text": "*HostName:*\nhttps://github.com"
+// 				}
+// 			]
+// 		}
+// 	]
+// }
+
+func NewAccessApprovedView() {}
+
+func NewRequestAccessMsg(userName string, db string, roles []string) []slack.Block {
+	return []slack.Block{
+		slack.SectionBlock{
+			Type: slack.MBTSection,
+			Text: slack.NewTextBlockObject(slack.PlainTextType, fmt.Sprintf("%s have requested access", userName), false, false),
+		},
+		slack.SectionBlock{
+			Type: slack.MBTSection,
+			Fields: []*slack.TextBlockObject{
+				slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Database:*\n %s", db), false, false),
+				slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Roles:*\n %s", strings.Join(roles, ",")), false, false),
+			},
+		},
+		slack.ActionBlock{
+			Type: slack.MBTAction,
+			Elements: &slack.BlockElements{
+				ElementSet: []slack.BlockElement{
+					slack.ButtonBlockElement{
+						Type: slack.METButton,
+						Text: &slack.TextBlockObject{
+							Type: slack.PlainTextType,
+							Text: "Approve",
+						},
+						Style: "primary",
+						Value: "approved",
+					},
+					slack.ButtonBlockElement{
+						Type: slack.METButton,
+						Text: &slack.TextBlockObject{
+							Type: slack.PlainTextType,
+							Text: "Deny",
+						},
+						Style: "danger",
+						Value: "denied",
+					},
+				},
+			},
+		},
+	}
+}
+
+type ModalSubmission struct {
+	Values Values `json:"values"`
+}
+
+type Text struct {
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	Emoji bool   `json:"emoji"`
+}
+
+type SelectedOption struct {
+	Text  Text   `json:"text"`
+	Value string `json:"value"`
+}
+
+type Database struct {
+	Type           string         `json:"type"`
+	SelectedOption SelectedOption `json:"selected_option"`
+}
+
+type Databaseid struct {
+	Database Database `json:"database"`
+}
+
+type SelectedOptions struct {
+	Text  Text   `json:"text"`
+	Value string `json:"value"`
+}
+
+type Roles struct {
+	Type            string            `json:"type"`
+	SelectedOptions []SelectedOptions `json:"selected_options"`
+}
+
+type Rolesid struct {
+	Roles Roles `json:"roles"`
+}
+
+type Values struct {
+	Databaseid Databaseid `json:"databaseblock"`
+	Rolesid    Rolesid    `json:"rolesblock"`
+}

--- a/controlplane/slackbot/views.go
+++ b/controlplane/slackbot/views.go
@@ -21,6 +21,7 @@ import (
 	"github.com/slack-go/slack"
 )
 
+// NewRequestAccessModal will return request access modal view.
 func NewRequestAccessModal(requestID string, databases []*slack.OptionBlockObject,
 	roles []*slack.OptionBlockObject) slack.ModalViewRequest {
 	return slack.ModalViewRequest{
@@ -45,7 +46,7 @@ func NewRequestAccessModal(requestID string, databases []*slack.OptionBlockObjec
 					Type:    slack.MBTInput,
 					Element: slack.SelectBlockElement{
 						Type:        slack.OptTypeStatic,
-						Placeholder: slack.NewTextBlockObject(slack.PlainTextType, "slect database", false, false),
+						Placeholder: slack.NewTextBlockObject(slack.PlainTextType, "select database", false, false),
 						Options:     databases,
 						ActionID:    "database",
 					},
@@ -59,7 +60,7 @@ func NewRequestAccessModal(requestID string, databases []*slack.OptionBlockObjec
 					Type:    slack.MBTInput,
 					Element: slack.SelectBlockElement{
 						Type:        slack.MultiOptTypeStatic,
-						Placeholder: slack.NewTextBlockObject(slack.PlainTextType, "slect database", false, false),
+						Placeholder: slack.NewTextBlockObject(slack.PlainTextType, "select roles", false, false),
 						Options:     roles,
 						ActionID:    "roles",
 					},
@@ -73,6 +74,7 @@ func NewRequestAccessModal(requestID string, databases []*slack.OptionBlockObjec
 	}
 }
 
+// NewRequestSentView returns request sent view.
 func NewRequestSentView() slack.HomeTabViewRequest {
 	return slack.HomeTabViewRequest{
 		Type: slack.VTHomeTab,
@@ -87,6 +89,8 @@ func NewRequestSentView() slack.HomeTabViewRequest {
 	}
 }
 
+//NewBlockOptions takes options name and it's respective value as input then it returns
+// slack option block object.
 func NewBlockOptions(options []string, values []string) []*slack.OptionBlockObject {
 	opts := []*slack.OptionBlockObject{}
 	for i, option := range options {
@@ -98,6 +102,7 @@ func NewBlockOptions(options []string, values []string) []*slack.OptionBlockObje
 	return opts
 }
 
+// NewHomeTabView returns slack home tab view.
 func NewHomeTabView() slack.HomeTabViewRequest {
 	return slack.HomeTabViewRequest{
 		Type: slack.VTHomeTab,
@@ -125,38 +130,26 @@ func NewHomeTabView() slack.HomeTabViewRequest {
 	}
 }
 
-// credentials approved block
-// {
-// 	"blocks": [
-// 		{
-// 			"type": "section",
-// 			"text": {
-// 				"type": "mrkdwn",
-// 				"text": "Your access have approved. credentials can be found below"
-// 			}
-// 		},
-// 		{
-// 			"type": "section",
-// 			"fields": [
-// 				{
-// 					"type": "mrkdwn",
-// 					"text": "*Username:*\n postgresprod"
-// 				},
-// 				{
-// 					"type": "mrkdwn",
-// 					"text": "*Password:*\nadmin, deve, support"
-// 				},
-// 				{
-// 					"type": "mrkdwn",
-// 					"text": "*HostName:*\nhttps://github.com"
-// 				}
-// 			]
-// 		}
-// 	]
-// }
+// NewCredentialsBlock returns credentials block. This view is used to show the username and password
+// of the datasource.
+func NewCredentialsBlock(username, password, hostname string) []slack.Block {
+	return []slack.Block{
+		slack.SectionBlock{
+			Type: slack.MBTSection,
+			Text: slack.NewTextBlockObject(slack.PlainTextType, "Your request has been approved", false, false),
+		},
+		slack.SectionBlock{
+			Type: slack.MBTSection,
+			Fields: []*slack.TextBlockObject{
+				slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Username:*\n %s", username), false, false),
+				slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Password:*\n %s", password), false, false),
+				slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Hostname:*\n %s", hostname), false, false),
+			},
+		},
+	}
+}
 
-func NewAccessApprovedView() {}
-
+// NewRequestAccessMsg returns approval modal for the admins.
 func NewRequestAccessMsg(userName string, db string, roles []string, callbackID string) []slack.Block {
 	return []slack.Block{
 		slack.SectionBlock{

--- a/controlplane/slackbot/views.go
+++ b/controlplane/slackbot/views.go
@@ -157,7 +157,7 @@ func NewHomeTabView() slack.HomeTabViewRequest {
 
 func NewAccessApprovedView() {}
 
-func NewRequestAccessMsg(userName string, db string, roles []string) []slack.Block {
+func NewRequestAccessMsg(userName string, db string, roles []string, callbackID string) []slack.Block {
 	return []slack.Block{
 		slack.SectionBlock{
 			Type: slack.MBTSection,
@@ -180,8 +180,9 @@ func NewRequestAccessMsg(userName string, db string, roles []string) []slack.Blo
 							Type: slack.PlainTextType,
 							Text: "Approve",
 						},
-						Style: "primary",
-						Value: "approved",
+						Style:    "primary",
+						Value:    callbackID,
+						ActionID: "approved",
 					},
 					slack.ButtonBlockElement{
 						Type: slack.METButton,
@@ -189,8 +190,9 @@ func NewRequestAccessMsg(userName string, db string, roles []string) []slack.Blo
 							Type: slack.PlainTextType,
 							Text: "Deny",
 						},
-						Style: "danger",
-						Value: "denied",
+						Style:    "danger",
+						Value:    "denied",
+						ActionID: "denied",
 					},
 				},
 			},

--- a/controlplane/store/store.go
+++ b/controlplane/store/store.go
@@ -319,6 +319,26 @@ func (s *Store) SyncRoles(objectID uint, objectType string, roles []string) erro
 	return s.WriteRoleForObjectID(objectID, roles, objectType)
 }
 
+// GetRoles return unique name of all the roles.
+func (s *Store) GetRoles() ([]string, error) {
+	results := []*models.Role{}
+	err := s.db.Model(&models.Role{}).Distinct("name").Find(&results).Error
+	if err != nil {
+		return nil, err
+	}
+	roles := []string{}
+	for _, result := range results {
+		roles = append(roles, result.Name)
+	}
+	return roles, nil
+}
+
+func (s *Store) GetDataSource() ([]*models.DataSource, error) {
+	result := []*models.DataSource{}
+	err := s.db.Model(&models.DataSource{}).Find(&result).Error
+	return result, err
+}
+
 func handleGormErr(err error) error {
 	if err == nil {
 		return nil

--- a/controlplane/store/store.go
+++ b/controlplane/store/store.go
@@ -6,7 +6,6 @@ import (
 	"inspektor/models"
 	"inspektor/types"
 	"inspektor/utils"
-	"net/http"
 	"time"
 
 	"github.com/goombaio/namegenerator"
@@ -348,7 +347,6 @@ func (s *Store) CreateTempSession(datasourceID uint, roles []string, expiryMinut
 		return nil, err
 	}
 	if len(roles) == 0 {
-		utils.WriteErrorMsg("expected atleast one role to create session", http.StatusBadRequest, ctx.Rw)
 		return nil, errors.New("atleast one roles is expected to create temp session")
 	}
 	if expiryMinute == 0 {


### PR DESCRIPTION
This PR adds slack integration, where users in the team can request for temporary credentials to the datasources.

Later, this can be used to alert and daily report the usage 

#16 close